### PR TITLE
Support scale size for CGContext when using `addImageToImage:atRect`

### DIFF
--- a/UIImage+BlurredFrame.m
+++ b/UIImage+BlurredFrame.m
@@ -25,7 +25,7 @@
 - (UIImage *) addImageToImage:(UIImage *)img atRect:(CGRect)cropRect{
     
     CGSize size = CGSizeMake(self.size.width, self.size.height);
-    UIGraphicsBeginImageContext(size);
+    UIGraphicsBeginImageContextWithOptions(size, NO, self.scale);
     
     CGPoint pointImg1 = CGPointMake(0,0);
     [self drawAtPoint:pointImg1];


### PR DESCRIPTION
We need to use `UIGraphicsBeginImageContextWithOptions(size, NO, self.scale);` instead of `UIGraphicsBeginImageContext(size);` when handling CGContext because of scaling for image.

An image will be jugged if not use it.
