### PR TITLE
Orientation normalisation before cropping/merging

### DIFF
--- a/UIImage+BlurredFrame.m
+++ b/UIImage+BlurredFrame.m
@@ -14,6 +14,7 @@
     frame = CGRectMake(frame.origin.x * self.scale, frame.origin.y * self.scale, frame.size.width * self.scale, frame.size.height * self.scale);
     UIImage *rotatedImage = self;
     // make sure its orientation is up otherwise later on we'll have trouble merging
+    // based on this gist: https://gist.github.com/aleph7/5717438
     if (self.imageOrientation != UIImageOrientationUp) {
         rotatedImage = [self addImageToImage:nil atRect:CGRectZero];
     }

--- a/UIImage+BlurredFrame.m
+++ b/UIImage+BlurredFrame.m
@@ -10,32 +10,37 @@
 
 @implementation UIImage (BlurredFrame)
 
--(UIImage *)croppedImageAtFrame:(CGRect)frame
-{
+- (UIImage *)croppedImageAtFrame:(CGRect)frame {
     frame = CGRectMake(frame.origin.x * self.scale, frame.origin.y * self.scale, frame.size.width * self.scale, frame.size.height * self.scale);
-    CGImageRef sourceImageRef = [self CGImage];
+    UIImage *rotatedImage = self;
+    // make sure its orientation is up otherwise later on we'll have trouble merging
+    if (self.imageOrientation != UIImageOrientationUp) {
+        rotatedImage = [self addImageToImage:nil atRect:CGRectZero];
+    }
+    CGImageRef sourceImageRef = [rotatedImage CGImage];
     CGImageRef newImageRef = CGImageCreateWithImageInRect(sourceImageRef, frame);
-    UIImage *newImage = [UIImage imageWithCGImage:newImageRef scale:[self scale] orientation:[self imageOrientation]];
+    UIImage *newImage = [UIImage imageWithCGImage:newImageRef scale:[self scale] orientation:UIImageOrientationUp];
     CGImageRelease(newImageRef);
     return newImage;
 }
 
-#pragma mark - Marge two Images
+#pragma mark - Merge two Images
 
-- (UIImage *) addImageToImage:(UIImage *)img atRect:(CGRect)cropRect{
-    
-    CGSize size = CGSizeMake(self.size.width, self.size.height);
+- (UIImage *)addImageToImage:(UIImage *)img atRect:(CGRect)cropRect {
+    CGSize size = self.size;
     UIGraphicsBeginImageContextWithOptions(size, NO, self.scale);
-    
-    CGPoint pointImg1 = CGPointMake(0,0);
+  
+    CGPoint pointImg1 = CGPointMake(0, 0);
     [self drawAtPoint:pointImg1];
-    
-    CGPoint pointImg2 = cropRect.origin;
-    [img drawAtPoint: pointImg2];
-    
-    UIImage* result = UIGraphicsGetImageFromCurrentImageContext();
+  
+    if (img != nil && !CGRectEqualToRect(CGRectZero, cropRect)) {
+        CGPoint pointImg2 = cropRect.origin;
+        [img drawAtPoint:pointImg2];
+    }
+  
+    UIImage *result = UIGraphicsGetImageFromCurrentImageContext();
     UIGraphicsEndImageContext();
-    
+  
     return result;
 }
 


### PR DESCRIPTION
Hello
I'm not sure whether this issue appeared only in recent versions of iOS, as I have not tested anything but 9.x. Yet now this method is not working correctly for rotated images - 'applyTintEffectWithColor:atFrame:'.
Frame is applied correctly, to a correct part to an image. But then it is stretched incorrectly and inserted into a wrong position. Please see screenshot for example:
http://take.ms/BPlY8
Left side is correct (fixed) highlight.
Right side takes an originally rotated image (captured by the camera 'on the side'), crops desired area, blurs it, but then stretches it incorrectly and inserts into wrong position.

I fixed this by 'normalising' image first - translating into OrientationUp, if it's not already.
Original code is doing this again implicitly later on, when two images are merged, thus forcing OrientationUp any way.

Does it make sense to merge this fix and release a Pod update?

Btw, thank you for the library :)
